### PR TITLE
Get file diagnostics instead of global diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-strict-null-checks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Eslint plugin that aims to reproduce strictNullCheck from tsconfig for easier migration",
   "main": "dist/index.js",
   "scripts": {

--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -26,8 +26,8 @@ export default createEslintRule<Options, MessageIds>({
 
     return {
       Program(astNode) {
-        const semErrors = parserServices.program.getSemanticDiagnostics();
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(astNode);
+        const semErrors = parserServices.program.getSemanticDiagnostics(tsNode);
         const code = tsNode.text;
 
         semErrors.forEach((error) => {


### PR DESCRIPTION
Hey Jarosław, thanks for making this plugin.

I noticed that this plugin was taking up a lot of time and memory in our codebase. I tinkered around with the plugin and discovered that `getSemanticDiagnostics` accepts a `SourceFile`. Passing this file into `getSemanticDiagnostics` yields the same errors but with significantly improved performance. I measured a 5x speed improvement when linting our entire codebase, and linting a single file finishes in milliseconds rather than 20 seconds.

I haven't measured memory usage, but I assume this has been reduced as well.

Should help with: https://github.com/JaroslawPokropinski/eslint-plugin-strict-null-checks/issues/30

## Performance Comparison

### Before

Entire codebase
![image](https://github.com/user-attachments/assets/36411bfd-98f1-47f9-b29f-c1f5b5b4fe4d)

Single file
![image](https://github.com/user-attachments/assets/ca0a0f22-25e5-42de-84d6-b3bf2ee835dc)

### After

Entire codebase
![image](https://github.com/user-attachments/assets/0fc1b73d-5aba-44b7-9698-e1e63d1dd17e)

Single file
![image](https://github.com/user-attachments/assets/18774ef5-4ef4-4db3-8c4b-db08b9963af6)